### PR TITLE
ads support for query variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-to-graphql-query",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "main": "lib/index.js",
   "license": "MIT",
   "scripts": {

--- a/src/__tests__/jsonToGraphQLQuery.tests.ts
+++ b/src/__tests__/jsonToGraphQLQuery.tests.ts
@@ -1,6 +1,6 @@
 
 import { expect } from 'chai';
-import { jsonToGraphQLQuery, EnumType } from '../';
+import { jsonToGraphQLQuery, EnumType, VariableType } from '../';
 
 describe('jsonToGraphQL()', () => {
 
@@ -304,4 +304,42 @@ describe('jsonToGraphQL()', () => {
         'query { Posts (a: false) { id } Lorem { id } }'
       );
     });
+});
+
+it('converts a query variables', () => {
+    const query = {
+        query: {
+            __variables: {
+                variableName: 'String!'
+            },
+            Posts: {
+                __args: {
+                    arg1: 20,
+                    arg2: new VariableType('variableName')
+                },
+                id: true,
+                title: true,
+                comments: {
+                    __args: {
+                        offensiveOnly: true
+                    },
+                    id: true,
+                    comment: true,
+                    user: true
+                }
+            }
+        }
+    };
+    expect(jsonToGraphQLQuery(query, { pretty: true })).to.equal(
+`query ($variableName: String!) {
+    Posts (arg1: 20, arg2: $variableName) {
+        id
+        title
+        comments (offensiveOnly: true) {
+            id
+            comment
+            user
+        }
+    }
+}`);
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
-
 export * from './jsonToGraphQLQuery';
+export {EnumType} from './types/EnumType';
+export {VariableType} from './types/VariableType';

--- a/src/types/EnumType.ts
+++ b/src/types/EnumType.ts
@@ -1,0 +1,5 @@
+class EnumType {
+    constructor(public value: string) {}
+}
+
+export {EnumType};

--- a/src/types/VariableType.ts
+++ b/src/types/VariableType.ts
@@ -1,0 +1,5 @@
+class VariableType {
+    constructor(public value: string) {}
+}
+
+export {VariableType};


### PR DESCRIPTION
This ads support for query variables.

- Extracted type classes to separate files as only one class per file allowed
- Added `VariableType` class and renderer
- Added `__variables` field and builder
- Added corresponding test