### PR TITLE
- added @rest directive arg placement and removed quote replacer on d…

### DIFF
--- a/src/__tests__/directives.tests.ts
+++ b/src/__tests__/directives.tests.ts
@@ -33,6 +33,70 @@ describe('jsonToGraphQLQuery() - directives', () => {
 }`);
     });
 
+    it('places args in front of drirective if it is @rest', () => {
+        const path = "/foo"
+        
+        const query = {
+            query: {
+                Posts: {
+                    __args: {
+                        where: {
+                            id: 10,
+                        },
+                        orderBy: 'flibble'
+                    },
+                    __directives: {
+                        rest: { path }
+                    },
+                    id: true,
+                    title: true,
+                    post_date: true
+                }
+            }
+        } as any;
+        expect(jsonToGraphQLQuery(query, { pretty: true })).to.equal(
+            `query {
+    Posts (where: {id: 10}, orderBy: "flibble") @rest(path: "/foo")  {
+        id
+        title
+        post_date
+    }
+}`);
+    });
+
+    it('returns strings, arrays and objects in the directive args', () => {
+        const string = "/foo"
+        const object = { bar: 'baz' }
+        const array = ["complexities", "of", "naming", "conventions"]
+        
+        const query = {
+            query: {
+                Posts: {
+                    __args: {
+                        where: {
+                            id: 10,
+                        },
+                        orderBy: 'flibble'
+                    },
+                    __directives: {
+                        client: { string, object, array }
+                    },
+                    id: true,
+                    title: true,
+                    post_date: true
+                }
+            }
+        } as any;
+        expect(jsonToGraphQLQuery(query, { pretty: true })).to.equal(
+            `query {
+    Posts @client(string: "/foo", object: {bar: "baz"}, array: ["complexities", "of", "naming", "conventions"]) (where: {id: 10}, orderBy: "flibble") {
+        id
+        title
+        post_date
+    }
+}`);
+    });
+
     it('converts a complex query with directives with no arguments', () => {
         const query = {
             query: {

--- a/src/jsonToGraphQLQuery.ts
+++ b/src/jsonToGraphQLQuery.ts
@@ -56,7 +56,7 @@ function buildDirectives(dirsObj: any): string {
     else if (typeof directiveValue === 'object') {
         const args = [];
         for (const argName in directiveValue) {
-            const argVal = stringify(directiveValue[argName]).replace(/"/g, '');
+            const argVal = stringify(directiveValue[argName]);
             args.push(`${argName}: ${argVal}`);
         }
         return `${directiveName}(${args.join(', ')})`;
@@ -109,6 +109,7 @@ function convertQuery(node: any, level: number, output: Array<[string, number]>,
                 else if (argsExist || directivesExist) {
                     let argsStr: string;
                     let dirsStr: string;
+                    let dirStrIsRest: boolean = false;
                     if (directivesExist) {
                         // TODO: Add support for multiple directives on one node.
                         const numDirectives = Object.keys(value.__directives).length;
@@ -122,8 +123,12 @@ function convertQuery(node: any, level: number, output: Array<[string, number]>,
                     if (argsExist) {
                         argsStr = `(${buildArgs(value.__args)})`;
                     }
+                    if (dirsStr && dirsStr.includes('@rest')) {
+                        dirStrIsRest = true
+                    }
                     const spacer = directivesExist && argsExist ? ' ' : '';
-                    token = `${token} ${dirsStr ? dirsStr : ''}${spacer}${argsStr ? argsStr : ''}`;
+
+                    token = `${token}${dirStrIsRest && argsStr ? ` ${argsStr} ` : ' '}${dirsStr ? dirsStr : ''}${spacer}${!dirStrIsRest && argsStr ? argsStr : ''}`;
                 }
 
                 // DEPRECATED: Should be removed in version 2.0.0


### PR DESCRIPTION
**Issue**
Apollo rest-link uses the @rest directive to to determine if it is a rest query/mutation with a range of config passed into the args of the directive ( e.g. `@rest(path: "/foo")`). Currently if you want to use both `__directive` and `__args` for the same key, `json-to-graphql-query` will generate the following directive and arg shape `foo @rest(directive: args) (real: args)`. Apollo requires you to construct it like this - `foo  (real: args) @rest(directive: args)`. 

Additionally, as far as I am aware, there doesn't seem to be any reason for stripping the quotes `"` from the args passed into the directive. Currently if you want to have a string in the directive args you cannot.

**Solution**
1. Add a conditional to check for an @rest directive and place the args in front if @rest is present.
2. remove the quote replacer

This is my first time contributing to open source projects so if there is anything I missed please let me know 😁 👍 .